### PR TITLE
Allow comment lines between step lines

### DIFF
--- a/examples/apes/features/monkey-behaviour.feature
+++ b/examples/apes/features/monkey-behaviour.feature
@@ -16,7 +16,7 @@ Feature: Monkeys behave as expected
    
   Examples: monkey characteristics:
   | fruit  | response  | manner_of_looking  |
-  | banana | happy     | quizically         |
+  | banana | happy     | quizzically         |
   | pear   | sad       | loathingly         |
    
   # This is a comment about this scenario outline...

--- a/src/tegere/core_fiddle.clj
+++ b/src/tegere/core_fiddle.clj
@@ -26,7 +26,7 @@
 
   (step-prsr " But he doesn't eat it\n")
 
-  (step-prsr " And he looks at me quizically\n")
+  (step-prsr " And he looks at me quizzically\n")
 
   (step-block-prsr
    (str
@@ -34,7 +34,7 @@
     " When I give him a banana\n"
     " Then he is happy\n"
     " But he doesn't eat it\n"
-    " And he looks at me quizically\n"
+    " And he looks at me quizzically\n"
     ))
 
   (scenario-line-prsr
@@ -58,7 +58,7 @@
     "    When I give him a banana\n"
     "    Then he is happy\n"
     "    But he doesn't eat it\n"
-    "    And he looks at me quizically\n"
+    "    And he looks at me quizzically\n"
     ))
 
   (scenario-prsr
@@ -69,7 +69,7 @@
     "    When I give him a banana\n"
     "    Then he is happy\n"
     "    But he doesn't eat it\n"
-    "    And he looks at me quizically\n"
+    "    And he looks at me quizzically\n"
     ))
 
   (scenario-outline-prsr
@@ -80,7 +80,7 @@
     "    When I give him a banana\n"
     "    Then he is happy\n"
     "    But he doesn't eat it\n"
-    "    And he looks at me quizically\n"
+    "    And he looks at me quizzically\n"
     "   \n"
     "  Examples: monkey characteristics:\n"
     "  | h1  | h2  | h3  |\n"
@@ -157,7 +157,7 @@
     "    When I give him a banana\n"
     "    Then he is happy\n"
     "    But he doesn't eat it\n"
-    "    And he looks at me quizically\n"
+    "    And he looks at me quizzically\n"
     "   \n"
     "  Examples: monkey characteristics:\n"
     "  | h1  | h2  | h3  |\n"
@@ -170,7 +170,7 @@
     "    When I give him a banana\n"
     "    Then he is happy\n"
     "    But he doesn't eat it\n"
-    "    And he looks at me quizically\n"
+    "    And he looks at me quizzically\n"
     ))
 
   (feature-prsr
@@ -190,7 +190,7 @@
     "    When I give him a banana\n"
     "    Then he is happy\n"
     "    But he doesn't eat it\n"
-    "    And he looks at me quizically\n"
+    "    And he looks at me quizzically\n"
     "   \n"
     "   \n"
     "  Examples: monkey characteristics:\n"
@@ -206,7 +206,7 @@
     "    When I give him a banana\n"
     "    Then he is happy\n"
     "    But he doesn't eat it\n"
-    "    And he looks at me quizically\n"
+    "    And he looks at me quizzically\n"
     "\n"
     "\n"
     ))

--- a/src/tegere/grammar_fiddle.clj
+++ b/src/tegere/grammar_fiddle.clj
@@ -1,6 +1,7 @@
 (ns tegere.grammar-fiddle
   "Fiddle file for playing around with grammar.clj."
-  (:require [tegere.grammar :refer :all]))
+  (:require [clojure.string :as string]
+            [tegere.grammar :refer :all]))
 
 
 (def monkey-feature
@@ -25,7 +26,7 @@
    "   \n"
    "  Examples: monkey characteristics:\n"
    "  | fruit  | response  | manner_of_looking  |\n"
-   "  | banana | happy     | quizically         |\n"
+   "  | banana | happy     | quizzically        |\n"
    "  | pear   | sad       | loathingly         |\n"
    "   \n"
    "  # This is a comment about this scenario outline...\n"
@@ -46,6 +47,8 @@
 
   (step-label-prsr "Then")
 
+  (step-label-prsr "But")
+
   (step-prsr " Given a monkey\n")
 
   (step-prsr " When I give him a banana\n")
@@ -54,7 +57,7 @@
 
   (step-prsr " But he doesn't eat it\n")
 
-  (step-prsr " And he looks at me quizically\n")
+  (step-prsr " And he looks at me quizzically\n")
 
   (step-block-prsr
    (str
@@ -62,8 +65,26 @@
     " When I give him a banana\n"
     " Then he is happy\n"
     " But he doesn't eat it\n"
-    " And he looks at me quizically\n"
+    " And he looks at me quizzically\n"
     ))
+
+  ;; comments work inside step blocks and scenario outline step blocks:
+  (step-block-prsr
+   (str
+    " Given a monkey\n"
+    " #When I give him a banana\n"
+    " # Then he is happy\n"
+    "    #But he doesn't eat it\n"
+    "    #    And he looks at me quizzically\n"))
+
+  ;; comments work inside step blocks and scenario outline step blocks:
+  (so-step-block-prsr
+   (str
+    " Given a monkey\n"
+    " #When I give him a banana\n"
+    " Then he is happy\n"
+    " But he doesn't eat it\n"
+    " And he looks at me quizzically\n"))
 
   (scenario-line-prsr
    " Scenario: Monkeys are cautious when offered food.\n")
@@ -86,7 +107,7 @@
     "    When I give him a banana\n"
     "    Then he is happy\n"
     "    But he doesn't eat it\n"
-    "    And he looks at me quizically\n"
+    "    And he looks at me quizzically\n"
     ))
 
   (scenario-prsr
@@ -97,7 +118,7 @@
     "    When I give him a banana\n"
     "    Then he is happy\n"
     "    But he doesn't eat it\n"
-    "    And he looks at me quizically\n"
+    "    And he looks at me quizzically\n"
     ))
 
   (scenario-outline-prsr
@@ -108,7 +129,7 @@
     "    When I give him a banana\n"
     "    Then he is happy\n"
     "    But he doesn't eat it\n"
-    "    And he looks at me quizically\n"
+    "    And he looks at me quizzically\n"
     "   \n"
     "  Examples: monkey characteristics:\n"
     "  | h1  | h2  | h3  |\n"
@@ -185,7 +206,7 @@
     "    When I give him a banana\n"
     "    Then he is happy\n"
     "    But he doesn't eat it\n"
-    "    And he looks at me quizically\n"
+    "    And he looks at me quizzically\n"
     "   \n"
     "  Examples: monkey characteristics:\n"
     "  | h1  | h2  | h3  |\n"
@@ -198,10 +219,13 @@
     "    When I give him a banana\n"
     "    Then he is happy\n"
     "    But he doesn't eat it\n"
-    "    And he looks at me quizically\n"
+    "    And he looks at me quizzically\n"
     ))
 
   (feature-prsr monkey-feature)
+
+  ;; Show that we can parse feature files that do not end with a newline.
+  (feature-prsr (string/trim monkey-feature))
 
   (let [real-feature
         (slurp (.getPath (clojure.java.io/resource "sample.feature")))]

--- a/src/tegere/runner_fiddle.clj
+++ b/src/tegere/runner_fiddle.clj
@@ -26,8 +26,8 @@
           "he is sad" (fn [context] (update-step-rets context :is-sad))
           "he looks at me loathingly"
           (fn [context] (update-step-rets context :looks-loathingly))
-          "he looks at me quizically"
-          (fn [context] (update-step-rets context :looks-quizically))}})
+          "he looks at me quizzically"
+          (fn [context] (update-step-rets context :looks-quizzically))}})
 
 (defn for-repl
   "Call this in a REPL to see how printing to stdout works."
@@ -48,8 +48,8 @@
                 "he is sad" (fn [context] (update-step-rets context :is-sad))
                 "he looks at me loathingly"
                 (fn [context] (update-step-rets context :looks-loathingly))
-                "he looks at me quizically"
-                (fn [context] (update-step-rets context :looks-quizically))}}]
+                "he looks at me quizzically"
+                (fn [context] (update-step-rets context :looks-quizzically))}}]
     (run features fake-registry config)))
 
 ;; Fake seq of scenario executions
@@ -152,7 +152,7 @@
       :fn nil
       :execution nil}
      {:type :then
-      :text "he looks at me quizically"
+      :text "he looks at me quizzically"
       :original-type :and
       :fn nil
       :execution nil}]
@@ -320,7 +320,7 @@
       :fn nil
       :execution nil}
      {:type :then
-      :text "he looks at me quizically"
+      :text "he looks at me quizzically"
       :original-type :and
       :fn nil
       :execution nil}]
@@ -457,7 +457,7 @@
       :fn nil
       :execution nil}
      {:type :then
-      :text "he looks at me quizically"
+      :text "he looks at me quizzically"
       :original-type :and
       :fn nil
       :execution nil}]
@@ -560,7 +560,7 @@
       :fn nil
       :execution nil}
      {:type :then
-      :text "he looks at me quizically"
+      :text "he looks at me quizzically"
       :original-type :and
       :fn nil
       :execution nil}]
@@ -867,8 +867,8 @@
                 "he is sad" (fn [context] (update-step-rets context :is-sad))
                 "he looks at me loathingly"
                 (fn [context] (update-step-rets context :looks-loathingly))
-                "he looks at me quizically"
-                (fn [context] (update-step-rets context :looks-quizically))}}]
+                "he looks at me quizzically"
+                (fn [context] (update-step-rets context :looks-quizzically))}}]
     (run features fake-registry config))
 
   (let [features [(parse monkey-feature) (parse monkey-feature)]
@@ -885,8 +885,8 @@
                 "he is sad" (fn [context] (update-step-rets context :is-sad))
                 "he looks at me loathingly"
                 (fn [context] (update-step-rets context :looks-loathingly))
-                "he looks at me quizically"
-                (fn [context] (update-step-rets context :looks-quizically))}}]
+                "he looks at me quizzically"
+                (fn [context] (update-step-rets context :looks-quizzically))}}]
     (run features fake-registry config))
 
   (get-step-fn-args

--- a/test/tegere/runner_test.clj
+++ b/test/tegere/runner_test.clj
@@ -26,7 +26,7 @@
    "   \n"
    "  Examples: monkey characteristics:\n"
    "  | fruit  | response  | manner_of_looking  |\n"
-   "  | banana | happy     | quizically         |\n"
+   "  | banana | happy     | quizzically         |\n"
    "  | pear   | sad       | loathingly         |\n"
    "   \n"
    "  # This is a comment about this scenario outline...\n"
@@ -65,8 +65,8 @@
           "he is sad" (fn [context] (update-step-rets context :is-sad))
           "he looks at me loathingly"
           (fn [context] (update-step-rets context :looks-loathingly))
-          "he looks at me quizically"
-          (fn [context] (update-step-rets context :looks-quizically))}})
+          "he looks at me quizzically"
+          (fn [context] (update-step-rets context :looks-quizzically))}})
 
 ;; This fake registry has a step function that takes parameters
 (def fake-registry-params
@@ -191,7 +191,7 @@
       :fn nil
       :execution nil}
      {:type :then
-      :text "he looks at me quizically"
+      :text "he looks at me quizzically"
       :original-type :and
       :fn nil
       :execution nil}]
@@ -359,7 +359,7 @@
       :fn nil
       :execution nil}
      {:type :then
-      :text "he looks at me quizically"
+      :text "he looks at me quizzically"
       :original-type :and
       :fn nil
       :execution nil}]
@@ -497,7 +497,7 @@
       :fn nil
       :execution nil}
      {:type :then
-      :text "he looks at me quizically"
+      :text "he looks at me quizzically"
       :original-type :and
       :fn nil
       :execution nil}]
@@ -600,7 +600,7 @@
       :fn nil
       :execution nil}
      {:type :then
-      :text "he looks at me quizically"
+      :text "he looks at me quizzically"
       :original-type :and
       :fn nil
       :execution nil}]
@@ -779,7 +779,7 @@
         ;; The contexts at the end of execution of each scenario shoulld reflect
         ;; the meaning of the scenario (because the fake registry is defined that
         ;; way.)
-        (t/is (= [[:a-monkey :give-banana :is-happy :not-eat :looks-quizically]
+        (t/is (= [[:a-monkey :give-banana :is-happy :not-eat :looks-quizzically]
                   [:a-monkey :give-pear :is-sad :not-eat :looks-loathingly]
                   [:a-monkey :present-with-orang :is-happy]]
                  [(nth exec-step-rets 4) (nth exec-step-rets 9)


### PR DESCRIPTION
- Now you can have comment lines interleaved between step lines.
- Other small improvements:

  - Fixed typo: "quizically".
  - Allow feature parser to handle feature file strings that do NOT end
    in a newline (by adding that newline.)