### PR TITLE
Fixes to the recent feature addition: add step data

### DIFF
--- a/src/tegere/grammar.clj
+++ b/src/tegere/grammar.clj
@@ -52,7 +52,7 @@
   (str
    "VARIABLE = <VLB> VARIABLE_NAME <VRB>\n"
    "VLB = '<'\n"
-   "<VARIABLE_NAME> = #'\\w+'\n"
+   "<VARIABLE_NAME> = #'[a-zA-Z_0-9\\?-]+'\n"
    "VRB = '>'\n"))
 
 (def step-grmr

--- a/src/tegere/runner.clj
+++ b/src/tegere/runner.clj
@@ -1,7 +1,8 @@
 (ns tegere.runner
   "Defines run, which runs a seq of features that match a supplied tags map,
   using the step functions defined in a supplied step-registry"
-  (:require [clojure.spec.alpha :as s]
+  (:require [clojure.pprint :as pprint]
+            [clojure.spec.alpha :as s]
             [clojure.string :as str]
             [tegere.utils :as u]
             [tegere.parser :as p]
@@ -124,9 +125,9 @@
   'I saw {fruit-type}' 'I ate a banana' => nil
   'I ate a pear'       'I ate a banana' => nil"
   [step-fn-text step-text]
-  (let [var-name-regex #"\{[-\w]+\}"
+  (let [var-name-regex #"\{[a-zA-Z_0-9\\?-]+\}"
         step-fn-regex
-        (-> step-fn-text (str/replace var-name-regex "(.+)") re-pattern)
+        (-> step-fn-text (str/replace var-name-regex "(.*)") re-pattern)
         matches (re-find step-fn-regex step-text)]
     (if matches
       (if (sequential? matches) (rest matches) ())
@@ -234,7 +235,7 @@
   triggered an error or whether an assertion failed."
   [step ctx]
   (try
-    (u/just ((::fn step) ctx))
+    (u/just ((::fn step) (assoc ctx ::p/step step)))
     (catch AssertionError e
       (handle-step-fail step e))
     (catch Exception e


### PR DESCRIPTION
The primary fix is to supply the parsed `:tegere.parser/step` to the step function under that very key in the context passed to the step function. Without this, the step implementation has no way to access the feature-supplied step data.

Also adds the hyphen and the question mark to the recognized characters of step variable names and cell values. Finally, allows step variables to match empty strings.